### PR TITLE
Heroku: Run on port dictated by heroku

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,8 @@ var yetify = require('yetify'),
     config = require('getconfig'),
     uuid = require('node-uuid'),
     crypto = require('crypto'),
-    io = require('socket.io').listen(config.server.port);
+    port = Number(process.env.PORT || config.server.port),
+    io = require('socket.io').listen(port);
 
 function describeRoom(name) {
     var clients = io.sockets.clients(name);
@@ -115,4 +116,4 @@ io.sockets.on('connection', function (client) {
 });
 
 if (config.uid) process.setuid(config.uid);
-console.log(yetify.logo() + ' -- signal master is running at: http://localhost:' + config.server.port);
+console.log(yetify.logo() + ' -- signal master is running at: http://localhost:' + port);


### PR DESCRIPTION
When running on heroku, we're not free to choose our own port. Heroku sets an environment variable telling us which port to use.

This commit looks for this environment variable and uses it in case.

This makes signalmaster run well on heroku (for me at least).
