### PR TITLE
move precommit-hook to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "getconfig": "0.3.0",
     "node-uuid": "1.2.0",
-    "precommit-hook": "0.3.10",
     "socket.io": "0.9.16",
     "yetify": "0.0.1"
   },
@@ -16,6 +15,7 @@
   },
   "devDependencies": {
     "socket.io-client": "0.9.16",
+    "precommit-hook": "0.3.10",
     "tape": "^2.13.1"
   },
   "scripts": {


### PR DESCRIPTION
precommit-hook is causing npm install errors on production server - but this should be a devDependency anyway.
