### PR TITLE
Updated to Socket.IO v1 api in case of active signalmaster's maxClients configuration

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -142,9 +142,10 @@ module.exports = function (server, config) {
     }
 
     function clientsInRoom(name) {
-        var room = io.sockets.adapter.rooms[name];
-        if (room && room.length) {
-            return room.length;
+        var adapter = io.nsps['/'].adapter;
+        var room = adapter.rooms[name];
+        if (room && Object.keys(room).length) {
+            return Object.keys(room).length;
         } else {
             return 0;
         }

--- a/sockets.js
+++ b/sockets.js
@@ -142,7 +142,12 @@ module.exports = function (server, config) {
     }
 
     function clientsInRoom(name) {
-        return io.sockets.clients(name).length;
+        var room = io.sockets.adapter.rooms[name];
+        if (room && room.length) {
+            return room.length;
+        } else {
+            return 0;
+        }
     }
 
 };


### PR DESCRIPTION
Just a trivial fix for Socket.IO v1, I encountered the bug using maxClients in the config. I wasn't sure if it's good to return 0 if the `room` is not valid (because I'm not sure how it can happen that is not valid).

Let me know if I need to adjust anything. 

(Thanks for signalmaster, btw :D)
